### PR TITLE
Fix a missing f-string f

### DIFF
--- a/dwq/dwqw.py
+++ b/dwq/dwqw.py
@@ -111,7 +111,7 @@ def worker(n, cmd_server_pool, gitjobdir, args, working_set):
                         job.done(
                             {
                                 "status": "error",
-                                "output": "{worker_str}: {error}\n",
+                                "output": f"{worker_str}: {error}\n",
                                 "worker": args.name,
                                 "runtime": 0,
                                 "body": job.body,


### PR DESCRIPTION
This should give insight into murdock errors that otherwise just say "{worker_str}: {error}"